### PR TITLE
#5 ReadOnlyCursor 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ### Java ###
 # Compiled class file
 *.class
+classes
 
 # Log file
 *.log

--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -224,6 +224,8 @@ import com.holub.tools.ArrayIterator;
 			return columnNames[index];
 		}
 
+		// bug: table.rows().column() always panics with NullPointerException.
+		// member variable 'row' cannot be instantiated.
 		public Object column(String columnName) {
 			return row[indexOf(columnName)];
 		}

--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -199,9 +199,11 @@ import com.holub.tools.ArrayIterator;
 		return new Results();
 	}
 
+	// ----------------------------------------------------------------------
+	// Read-only data getter
 	@Override
-	public ReadOnlyCursor readOnlyRows() {
-		return null;
+	public ReadOnlyCursor readOnlyCursor() {
+		return new ReadOnlyResult();
 	}
 
 	// ----------------------------------------------------------------------
@@ -275,6 +277,48 @@ import com.holub.tools.ArrayIterator;
 
 	// @cursor-end
 	// ----------------------------------------------------------------------
+
+    private final class ReadOnlyResult implements ReadOnlyCursor {
+        @Override
+        public Object[][] rows() {
+            Object[][] rows = new Object[rowSet.size()][columnNames.length];
+            for (int i = 0; i < rowSet.size(); i++) {
+                Object[] row = row(i);
+                for (int j = 0; j < row.length; j++) {
+                    rows[i][j] = row[j];
+                }
+            }
+
+            return rows;
+        }
+
+        @Override
+        public Object[] row(int index) throws IndexOutOfBoundsException {
+            return (Object[]) rowSet.get(index);
+        }
+
+        @Override
+        public Object[] column(String columnName) throws IndexOutOfBoundsException {
+            int colIdx = indexOf(columnName);
+            Object[] col = new Object[rowSet.size()];
+
+            for (int i = 0; i < rowSet.size(); i++) {
+                Object[] row = row(i);
+                col[i] = row[colIdx];
+            }
+
+            return col;
+        }
+
+        @Override
+        public int columnCount() {
+            return columnNames.length;
+        }
+    }
+
+	// @read_only_cursor-end
+	// ----------------------------------------------------------------------
+
 	// Undo subsystem.
 	//
 	private interface Undo {

--- a/src/com/holub/database/ConcreteTable.java
+++ b/src/com/holub/database/ConcreteTable.java
@@ -69,9 +69,9 @@ import com.holub.tools.ArrayIterator;
 
 	/**********************************************************************
 	 * Create a table with the given name and columns.
-	 * 
+	 *
 	 * @param tableName the name of the table.
-	 * @param an        array of Strings that specify the column names.
+	 * @param columnNames array of Strings that specify the column names.
 	 */
 	public ConcreteTable(String tableName, String[] columnNames) {
 		this.tableName = tableName;
@@ -197,6 +197,11 @@ import com.holub.tools.ArrayIterator;
 	//
 	public Cursor rows() {
 		return new Results();
+	}
+
+	@Override
+	public ReadOnlyCursor readOnlyRows() {
+		return null;
 	}
 
 	// ----------------------------------------------------------------------
@@ -511,7 +516,7 @@ import com.holub.tools.ArrayIterator;
 
 	/**
 	 * Insert an approved row into the result table:
-	 * 
+	 *
 	 * <PRE>
 	 * 		for( every requested column )
 	 * 			for( every table in the join )
@@ -519,7 +524,7 @@ import com.holub.tools.ArrayIterator;
 	 * 					add the associated value to the result table
 	 *
 	 * </PRE>
-	 * 
+	 *
 	 * Only one column with a given name is added, even if that column appears in
 	 * multiple tables. Columns in tables at the beginning of the list take
 	 * precedence over identically named columns that occur later in the list.
@@ -544,7 +549,7 @@ import com.holub.tools.ArrayIterator;
 	 * A collection variant on the array version. Just converts the collection to an
 	 * array and then chains to the other version
 	 * ({@linkplain #select(Selector,String[],Table[]) see}).
-	 * 
+	 *
 	 * @param requestedColumns the value returned from the {@link #toString} method
 	 *                         of the elements of this collection are used as the
 	 *                         column names.

--- a/src/com/holub/database/Database.java
+++ b/src/com/holub/database/Database.java
@@ -165,7 +165,7 @@ import com.holub.tools.ThrowableContainer;
  *	"id"=identifier, "opt"=optional, "e"=epsilon. "[...]" is
  *	an optional subproduction.
 <PRE>
-statement       ::= 
+statement       ::=
                     INSERT  INTO IDENTIFIER [LP idList RP]
                                       VALUES LP exprList RP
                 |   CREATE  DATABASE IDENTIFIER
@@ -180,7 +180,9 @@ statement       ::=
                                             EQUAL expr WHERE expr
                 |   DELETE  FROM IDENTIFIER WHERE expr
                 |   SELECT  [INTO identifier] idList
-                                        FROM idList [WHERE expr]
+                                        FROM idList [WHERE expr] [ORDER BY ids]
+
+ids 			::= WHITESPACE IDENTIFIER | IDENTIFIER
 
 idList          ::= IDENTIFIER idList' | STAR
 idList'         ::= COMMA IDENTIFIER idList'
@@ -291,7 +293,7 @@ public final class Database
 	 *  from the disk.
 	 */
 	private final class TableMap implements Map
-	{ 		
+	{
 		private final Map realMap;
 		public TableMap( Map realMap ){	this.realMap = realMap; }
 
@@ -324,12 +326,12 @@ public final class Database
 									in.failure( message ).getMessage() );
 			}
 		}
-		
+
 		public Object put(Object key, Object value)
 		{	// If transactions are active, put the new
 			// table into the same transaction state
 			// as the other tables.
-		
+
 			for( int i = 0; i < transactionLevel; ++i )
 				((Table)value).begin();
 
@@ -612,10 +614,10 @@ public final class Database
 	 *  @throws NoSuchElementException if no <code>begin()</code> was issued.
 	 */
 	public void commit() throws ParseFailure
-	{	
+	{
 		assert transactionLevel > 0 : "No begin() for commit()";
 		--transactionLevel;
-		
+
 		try
 		{	Collection currentTables = tables.values();
 			for( Iterator i = currentTables.iterator(); i.hasNext() ;)
@@ -644,7 +646,7 @@ public final class Database
 	}
 	//@transactions-end
 	//@parser-start
-	/******************************************************************* 
+	/*******************************************************************
 	 *  Execute a SQL statement. If an exception is tossed and we are in the
 	 *  middle of a transaction (a begin has been issued but no matching
 	 *  commit has been seen), the transaction is rolled back.
@@ -1194,7 +1196,7 @@ public final class Database
 
 				// Return true if both the left and right sides are instances
 				// of NullValue.
-				boolean isEqual = 
+				boolean isEqual =
 						leftValue.getClass() == rightValue.getClass();
 
 				return new BooleanValue(operator==EQ ? isEqual : !isEqual);
@@ -1310,7 +1312,7 @@ public final class Database
 		{	return value;
 		}
 		public String toString() // round down if the fraction is very small
-		{	
+		{
 			if( Math.abs(value - Math.floor(value)) < 1.0E-20 )
 				return String.valueOf( (long)value );
 			else
@@ -1421,7 +1423,7 @@ public final class Database
 			new Selector.Adapter()
 			{	public boolean approve(Cursor[] tables)
 				{	try
-					{	
+					{
 						Value result = where.evaluate(tables);
 
 						verify( result instanceof BooleanValue,
@@ -1437,7 +1439,7 @@ public final class Database
 		try
 		{	Table result = primary.select(selector, columns, participantsInJoin);
 
-			// If this is a "SELECT INTO <table>" request, remove the 
+			// If this is a "SELECT INTO <table>" request, remove the
 			// returned table from the UnmodifiableTable wrapper, give
 			// it a name, and put it into the tables Map.
 

--- a/src/com/holub/database/ReadOnlyCursor.java
+++ b/src/com/holub/database/ReadOnlyCursor.java
@@ -2,10 +2,12 @@ package com.holub.database;
 
 import java.util.Iterator;
 
-public interface ReadOnlyCursor extends Iterator {
-    Iterator columns();
+public interface ReadOnlyCursor {
+    Object[][] rows();
 
-    Object column(String columnName);
+    Object[] row(int index);
+
+    Object[] column(String columnName) throws IndexOutOfBoundsException;
 
     int columnCount();
 }

--- a/src/com/holub/database/ReadOnlyCursor.java
+++ b/src/com/holub/database/ReadOnlyCursor.java
@@ -1,0 +1,11 @@
+package com.holub.database;
+
+import java.util.Iterator;
+
+public interface ReadOnlyCursor extends Iterator {
+    Iterator columns();
+
+    Object column(String columnName);
+
+    int columnCount();
+}

--- a/src/com/holub/database/Table.java
+++ b/src/com/holub/database/Table.java
@@ -244,6 +244,8 @@ public interface Table extends Serializable, Cloneable
 	 */
 	Cursor rows();
 
+	ReadOnlyCursor readOnlyRows();
+
 	/** Build a representation of the Table using the
 	 *  specified Exporter. Create an object from an
 	 *  {@link Table.Importer} using the constructor with an

--- a/src/com/holub/database/Table.java
+++ b/src/com/holub/database/Table.java
@@ -28,7 +28,6 @@ package com.holub.database;
 
 import java.io.*;
 import java.util.*;
-import com.holub.database.Selector;
 
 /** A table is a database-like table that provides support for
  *  queries.
@@ -244,7 +243,7 @@ public interface Table extends Serializable, Cloneable
 	 */
 	Cursor rows();
 
-	ReadOnlyCursor readOnlyRows();
+	ReadOnlyCursor readOnlyCursor();
 
 	/** Build a representation of the Table using the
 	 *  specified Exporter. Create an object from an

--- a/src/com/holub/database/UnmodifiableTable.java
+++ b/src/com/holub/database/UnmodifiableTable.java
@@ -99,9 +99,8 @@ public class UnmodifiableTable implements Table
 	{	return wrapped.rows();
 	}
 
-	@Override
-	public ReadOnlyCursor readOnlyRows() {
-		return null;
+	public ReadOnlyCursor readOnlyCursor()
+	{	return wrapped.readOnlyCursor();
 	}
 
 	public void  export(Table.Exporter exporter) throws IOException

--- a/src/com/holub/database/UnmodifiableTable.java
+++ b/src/com/holub/database/UnmodifiableTable.java
@@ -98,6 +98,12 @@ public class UnmodifiableTable implements Table
 	public Cursor rows()
 	{	return wrapped.rows();
 	}
+
+	@Override
+	public ReadOnlyCursor readOnlyRows() {
+		return null;
+	}
+
 	public void  export(Table.Exporter exporter) throws IOException
 	{	wrapped.export(exporter);
 	}

--- a/test/com/holub/database/DatabaseTest.java
+++ b/test/com/holub/database/DatabaseTest.java
@@ -1,6 +1,41 @@
 package com.holub.database;
 
-import junit.framework.TestCase;
+import com.holub.text.ParseFailure;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
 
-public class DatabaseTest extends TestCase {
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DatabaseTest {
+
+    @Test
+    @DisplayName("ReadOnlyCursor 테스트")
+    public void testReadOnlyCursor() throws IOException, ParseFailure, IndexOutOfBoundsException {
+        Database database = new Database("Dbase");
+        database.begin();
+
+        Table lastNames = database.execute("select * from name");
+        ReadOnlyCursor readOnlyCursor = lastNames.readOnlyCursor();
+
+        // rows test
+        Object[][] rows = readOnlyCursor.rows();
+        Object[][] expectedRows = {
+                {"Fred", "Flintstone", "1"},
+                {"Wilma", "Flintstone", "1"},
+                {"Allen", "Holub", "0"},
+        };
+        assertArrayEquals(rows, expectedRows);
+
+        // row test
+        Object[] firstRow = readOnlyCursor.row(0);
+        Object[] expectedFirstRow = {"Fred", "Flintstone", "1"};
+        assertArrayEquals(firstRow, expectedFirstRow);
+
+        // last column test
+        Object[] lastCol = readOnlyCursor.column("last");
+        Object[] expectedLastCol = {"Flintstone", "Flintstone", "Holub"};
+        assertArrayEquals(lastCol, expectedLastCol);
+    }
 }


### PR DESCRIPTION
## 작업사항

* #5 
* order by parsing 문법 정의
* ReadOnlyCursor 구현
* ReadOnlyCursor 테스트코드 작성

## 변경로직
* 기존의 Cursor인터페이스에서는 rows를 바로 읽을 수 있는 메소드가 없었음.
* 바로 데이터를 확인하기 위한 ReadOnlyCursor를 추가적으로 구현함.

## Bug report
기존 Cursor인터페이스의 rows().columns()를 호출하면 반드시 NullPointerException 발생

close #5