### PR TITLE
#2 XMLImporter 구현, XMLImport JUnit Test 성공

### DIFF
--- a/src/com/holub/database/XMLImporter.java
+++ b/src/com/holub/database/XMLImporter.java
@@ -1,0 +1,113 @@
+package com.holub.database;
+
+import java.io.IOException;
+import org.w3c.dom.*;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+/***
+ *	Pass this importer to a {@link Table} constructor (such
+ *	as
+ *	{link com.holub.database.ConcreteTable#ConcreteTable(Table.Importer)}
+ *	to initialize
+ *	a <code>Table</code> from
+ *	a comma-sparated-value repressentation. For example:
+ *	<PRE>
+ *	// xml parse builder
+ *  name4 = new ConcreteTable( new XMLImporter(string_path) );
+ *  doc.close();
+ *	</PRE>
+ *	The input file for a table called "name4" with
+ *	columns "first," "last," and "admission" would look
+ *	like this:
+ *	<PRE>
+ *	<users>
+ *	    <ROW>
+ *	        <first>이름</first>
+ *	        <last>성</last>
+ *	        <gender>Male</gender>
+ *	    </ROW>
+ *	    ...
+ *	</users>
+ *	</PRE>
+ *	The root element is the table name, the sibling of root's first child
+ *	identifies the columns, and the sibling value define
+ *	the rows.
+ *
+ * @include /etc/license.txt
+ *
+ * @see Table
+ * @see Table.Importer
+// * @see XMLExporter
+ */
+
+public class XMLImporter implements Table.Importer
+{
+    private final Document doc;
+    private final ArrayList<String> columnNames = new ArrayList<>();
+    private String tableName;
+    int rowIdx = 0;
+
+    public XMLImporter(String in) throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        this.doc = builder.parse(in);
+        doc.getDocumentElement().normalize();
+    }
+
+    @Override
+    public void startTable() throws IOException {
+        Element root = doc.getDocumentElement();
+        tableName = root.getNodeName();
+        Node node = root.getFirstChild().getNextSibling();
+        NodeList childNodes = node.getChildNodes();
+        for(int i = 0; i < childNodes.getLength(); i++) {
+            Node item = childNodes.item(i);
+            if (item.getNodeType() == Node.ELEMENT_NODE) {
+                columnNames.add(item.getNodeName());
+            }
+        }
+    }
+
+    @Override
+    public String loadTableName() {
+        return tableName;
+    }
+
+    @Override
+    public int loadWidth() {
+        return columnNames.size();
+    }
+
+    @Override
+    public Iterator loadColumnNames() {
+        return columnNames.iterator();
+    }
+
+    @Override
+    public Iterator loadRow() {
+        Node node = doc.getElementsByTagName("ROW").item(rowIdx);
+        if (node != null)
+        {
+            ArrayList<String> rowList = new ArrayList<>();
+            NodeList data = node.getChildNodes();
+            for (int j = 0; j < data.getLength(); j++) {
+                Node rowNode = data.item(j);
+                if (rowNode.getNodeType() == Node.ELEMENT_NODE) {
+                    rowList.add(rowNode.getTextContent());
+                }
+            }
+            rowIdx++;
+            return rowList.iterator();
+        }
+        return null;
+    }
+
+    @Override
+    public void endTable() throws IOException {}
+}

--- a/test/com/holub/database/XMLImporterTest.java
+++ b/test/com/holub/database/XMLImporterTest.java
@@ -1,0 +1,51 @@
+package com.holub.database;
+
+import org.junit.jupiter.api.*;
+
+import java.io.*;
+import java.util.Iterator;
+import static org.junit.jupiter.api.Assertions.*;
+
+class XMLImporterTest {
+    private XMLImporter importer;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        String xmlString = "<table>" +
+                "<ROW><column1>Data1</column1><column2>Data2</column2></ROW>" +
+                "<ROW><column1>Data3</column1><column2>Data4</column2></ROW>" +
+                "</table>";
+
+        importer = new XMLImporter(new StringReader((xmlString)));
+    }
+
+    @Test
+    void testStartTable() throws IOException {
+        importer.startTable();
+        assertEquals("table", importer.loadTableName());
+        assertEquals(2, importer.loadWidth());
+    }
+
+    @Test
+    void testLoadRow() {
+        Iterator<String> row = importer.loadRow();
+        assertNotNull(row);
+        assertEquals("Data1", row.next());
+        assertEquals("Data2", row.next());
+        assertFalse(row.hasNext());
+
+        row = importer.loadRow();
+        assertEquals("Data3", row.next());
+        assertEquals("Data4", row.next());
+        assertFalse(row.hasNext());
+
+        row = importer.loadRow();
+        assertNull(row);
+    }
+
+    @Test
+    void testEndTable() throws IOException {
+        importer.endTable();
+        // 아무것도 하지 않는 메소드입니다.
+    }
+}


### PR DESCRIPTION
## 작업사항
1. XML Parser: XML 문서를 읽고 파싱하는 데 사용됩니다. javax.xml.parsers 패키지의 DocumentBuilder 클래스를 사용
2. Importer: Interface의 method override
3. Junit Test

## 변경로직
XMLImporter 추가

close #2 